### PR TITLE
Tweaks to RestOptions

### DIFF
--- a/lib/rest.ts
+++ b/lib/rest.ts
@@ -9,9 +9,15 @@ export interface RestOptions {
 
   /**
    * Body of the request.
+   * Can be either a string or an object.
+   */
+  body?: string | Record<string, any>;
+
+  /**
+   * Headers for the request.
    * Must be an object.
    */
-  body?: Record<string, any>;
+  headers?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
- Body can either be a string or a `Record`.
- Request headers can be set inside a `Record<string, string>`.